### PR TITLE
Various additions to FPS monitor

### DIFF
--- a/SparenDNHAPM.dnh
+++ b/SparenDNHAPM.dnh
@@ -290,8 +290,16 @@ task APM_StartFPS {
     ObjFile_OpenNW(outputfile, outputfilepath);
     let csvlog = ""; // CSV log
     let counter = 0;
+    let CORRECTION_FACTOR = 1.0325; // experimental 
+    let time_start;
+    let time_end;
+    let cfps;
     while(!finished) {
-        let cfps = GetCurrentFps();
+        time_start = GetStageTime();
+        loop(FEATURE_FPS_UPDATEFREQ){yield;}
+        time_end = GetStageTime();
+        cfps = CORRECTION_FACTOR * 1000 * FEATURE_FPS_UPDATEFREQ / (time_end - time_start);
+
         csvlog = csvlog ~ vtos("1.2f", cfps) ~ ",";
         // If csvlog is getting too long, push it to the File Object
         if (counter % 128 == 0) {
@@ -299,7 +307,6 @@ task APM_StartFPS {
             csvlog = "";
         }
         counter += 1;
-        loop(FEATURE_FPS_UPDATEFREQ){yield;}
     }
     // Flush to file
     ObjFileT_AddLine(outputfile, csvlog);
@@ -329,7 +336,10 @@ function APM_ChartGenFPS {
     // X Axis Labels
     svg = svg ~ SVGXAxisGen(maxtime * FEATURE_FPS_UPDATEFREQ/60);
     // Y Axis Labels
-    svg = svg ~ SVGYAxisGen(maxfps, "FPS");
+    let maxval = max(maxfps, 60);
+    svg = svg ~ SVGYAxisGen(maxval, "FPS");
+    // 60FPS line
+    svg = svg ~ "<path d=\"M 64 " ~ ToString(4 + (300 - 300*(60/maxval))) ~ " H 99999\" stroke=\"#AAAAAA\" stroke-width=\"1\" fill=\"none\" stroke-dasharray=\"4\" opacity=\"0.5\"></path>";
     // Add paths
     ascent(i in 0..length(paths)) {
         svg = svg ~ paths[i];
@@ -668,13 +678,14 @@ function APM_ChartGenCommon(apmtype, updfreq, linecolor) {
             // Generate path. If filepathlist[i] is the current file, then opacity is set to 1, AGGREGATE_LINE_OPACITY otherwise.
             let opacity = 1;
             if (filepathlist[i] != currfilepath) {opacity = AGGREGATE_LINE_OPACITY;}
-            let newpath = "<path d=\"M 64 304 ";
+            let newpath = "<path d=\"";
             // Iterate over the data points. Recall that by default, a second is one pixel.
             // Also recall that each data point is updfreq frames apart.
             let basex = 64;
             ascent(j in 0..length(filedatapoints)) {
                 let nodex = basex + j * updfreq/60 * GRAPH_SCALE;
                 let nodey = 304 - 300 * ator(filedatapoints[j])/maxval;
+                if(j==0){ newpath = newpath ~ "M " ~ ToString(nodex) ~ " " ~ ToString(nodey) ~ " "; }
                 newpath = newpath ~ "L " ~ ToString(nodex) ~ " " ~ ToString(nodey) ~ " ";
             }
             newpath = newpath ~ "\" stroke=\"" ~ linecolor ~ "\" stroke-width=\"1\" fill=\"none\" opacity=\"" ~ ToString(opacity) ~ "\"></path>";


### PR DESCRIPTION
I changed the FPS monitor to track FPS based on time passed rather than using DNH's function. This means you have much greater control over the tick. I haven't tested it a whole lot but this is how I tend to do it myself. One caveat is that for a reason I can't quite pin down this method consistently reports slightly less FPS than GetCurrentFps (likely somehow because it's all calculated from script rather than by the program itself), so there's a manual constant factor to fix it to be more or less consistent with what GetCurrentFps reports on average.

I've added a line to mark 60FPS on the graph as this will generally be what people want to target. I've also set 60 FPS to be the minimum value of the top of the graph for the same reason (if your program is somehow always running under 60FPS).

I've changed the line drawings so it moves the beginning of the graph to the first coordinate rather than at the static (0, 0) spot, mainly because having the 0 FPS at the beginning of every graph was annoying me and it's technically incorrect. The other things start at 0 so it didn't affect those, but it would affect FPS along with other user-defined stuff.

Here are pictures of 10-frame update and 2-frame update:
![](https://i.imgur.com/yCaph6d.png)
![](https://i.imgur.com/HOXVmxE.png)